### PR TITLE
enhance the post binding message in case the base64 is inflated

### DIFF
--- a/src/listener.js
+++ b/src/listener.js
@@ -132,8 +132,12 @@ const processSamlPostBindingMessage = (data) => {
       return;
     }
 
-    const decoded = window.atob(message);
-
+    var decoded = window.atob(message);
+    if (decoded.indexOf("xml version") == -1) {
+      const inflatedBytes = pako.inflateRaw(decoded, { to: 'string' });
+      const inflated = decodeURIComponent(inflatedBytes);
+      decoded = inflated;
+    }
     const parameters = [];
     for (const [name, value] of Object.entries(formData)) {
       parameters.push({ name, value });


### PR DESCRIPTION
some service provider use inflated based64 even in post binding, so just compatible with this situation, double check the based64 decode.